### PR TITLE
Fix indices query while maintaining performance

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1222,10 +1222,22 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                 name = database;
                 database = this.driver.database || currentDatabase;
             }
-            return `(\`s\`.\`TABLE_SCHEMA\` = '${database}' AND \`s\`.\`TABLE_NAME\` = '${name}' AND \`rc\`.\`CONSTRAINT_SCHEMA\` = '${database}' AND \`rc\`.\`TABLE_NAME\` = '${name}')`;
+            return `(\`s\`.\`TABLE_SCHEMA\` = '${database}' AND \`s\`.\`TABLE_NAME\` = '${name}')`;
         }).join(" OR ");
+
+        const indicesSubQueryCondition = tableNames.map(tableName => {
+            let [database, name] = tableName.split(".");
+            if (!name) {
+                name = database;
+                database = this.driver.database || currentDatabase;
+            }
+            return `(\`rcsub\`.\`CONSTRAINT_SCHEMA\` = '${database}' AND \`rcsub\`.\`TABLE_NAME\` = '${name}')`;
+        }).join(" OR ");
+
+        const indicesSubQuery = `SELECT \`rcsub\`.* FROM \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rcsub\` WHERE (${indicesSubQueryCondition})`;
+
         const indicesSql = `SELECT \`s\`.* FROM \`INFORMATION_SCHEMA\`.\`STATISTICS\` \`s\` ` +
-            `LEFT JOIN \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rc\` ON \`s\`.\`INDEX_NAME\` = \`rc\`.\`CONSTRAINT_NAME\` AND \`s\`.\`TABLE_SCHEMA\` = \`rc\`.\`CONSTRAINT_SCHEMA\`` +
+            `LEFT JOIN (${indicesSubQuery}) \`rc\` ON \`s\`.\`INDEX_NAME\` = \`rc\`.\`CONSTRAINT_NAME\` AND \`s\`.\`TABLE_SCHEMA\` = \`rc\`.\`CONSTRAINT_SCHEMA\`` +
             `WHERE (${indicesCondition}) AND \`s\`.\`INDEX_NAME\` != 'PRIMARY' AND \`rc\`.\`CONSTRAINT_NAME\` IS NULL`;
 
         const foreignKeysCondition = tableNames.map(tableName => {


### PR DESCRIPTION
When simply adding the where clause on a left join, we changed the query so that if no match was found the row wouldn't be returned.
Instead, perform the left join on a subquery with the where clause - that way the row will still be returned if there's no match, and the performance improvement is still kept.